### PR TITLE
Fixed spelling error "builings" in snap manifest.

### DIFF
--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: baugeschichte
 version: 2.0.2.7
-summary: See images and the history of builings in a city
-description: See images and the history of builings in a city downloaded from www.housetrails.org
+summary: See images and the history of buildings in a city
+description: See images and the history of buildings in a city downloaded from www.housetrails.org
 confinement: strict
 grade: stable
 


### PR DESCRIPTION
I went ahead and made an edit since the app was being shown on a featured spot in the Ubuntu Software Center. The snaps are getting a lot of  promotion in the latest update so the misspelling stood out on the page.